### PR TITLE
Fixed ro.json

### DIFF
--- a/lang/ro.json
+++ b/lang/ro.json
@@ -8,6 +8,7 @@
     "admins.addMute": "Adaugă Mute",
     "admins.addNewGroup": "Adaugă Grup Nou",
     "admins.addVIP": "Adaugă VIP",
+    "admins.panel": "Panel Admini",
     "admins.admin": "Admin",
     "admins.adminDoesntexists": "Adminul nu există pentru server! Adăugați Admin!",
     "admins.allGroups": "Toate Grupurile",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -9,6 +9,7 @@
     "admins.addNewGroup": "Adaugă Grup Nou",
     "admins.addVIP": "Adaugă VIP",
     "admins.panel": "Panel Admini",
+    "admins.settings": "Setari Admini",
     "admins.admin": "Admin",
     "admins.adminDoesntexists": "Adminul nu există pentru server! Adăugați Admin!",
     "admins.allGroups": "Toate Grupurile",


### PR DESCRIPTION
There was missing quotes in the ro.json file:
    "admins.panel": "Panel Admini",
    "admins.settings": "Setari Admini",
    Now it's all good.