### PR TITLE
Add playtime leaderboard

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -232,6 +232,7 @@
   "dashboard.bans": "Bans",
   "dashboard.connect": "Connect",
   "dashboard.csRating": "CS Rating",
+  "dashboard.playTime": "Play Time",
   "dashboard.deaths": "Deaths",
   "dashboard.expired": "Expired",
   "dashboard.expires": "Expires",

--- a/lang/en/dashboard.php
+++ b/lang/en/dashboard.php
@@ -16,6 +16,7 @@ return [
     'players' => 'Players',
     'player' => 'Player',
     'csRating' => 'CS Rating',
+    'playTime' => 'Play Time',
     'rank' => 'Rank',
     'kills' => 'Kills',
     'deaths' => 'Deaths',

--- a/resources/js/ranks/playtime.ts
+++ b/resources/js/ranks/playtime.ts
@@ -1,0 +1,55 @@
+import DataTable from 'datatables.net-dt';
+import 'datatables.net-responsive';
+let dataTable = null;
+function loadPlayTime() {
+    dataTable = new DataTable("#playTimeList", {
+        "processing": true,
+        "serverSide": true,
+        "responsive": true,
+        pageLength: 25,
+        "ajax": {
+            "url": playTimeListUrl,
+            "headers": {
+                "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+            },
+            "type": "POST",
+            "dataType": "json"
+        },
+        "language": {
+            "search": window.translations.searchByPlayernameAndSteamid,
+            'processing': '<div class="spinner"></div>'
+        },
+        order: [[2, 'desc']],
+        "columns": [
+            {"data": "position"},
+            {
+                "data": "name", "render": function (data, type, row, meta) {
+                    const truncatedName = truncatePlayerName(data);
+                    return `<div class="ranksList"><span class="list-profile"><a target="_blank" href="${row.profile}"><i class="fas fa-external-link-alt rank-profile"></i></a><img src="${row.avatar}" /><a href="https://steamcommunity.com/profiles/${row.player_steamid}">${truncatedName}</a></span><p class="text-muted mb-0">${window.translations.lastSeen}: <span class="badge badge-light-info rounded-pill d-inline">${row.last_seen}</span></p></div>`;
+                }
+            },
+            {"data": "playtime"},
+            {"data": "rank"},
+            {"data": "kills"},
+            {"data": "deaths"},
+            {"data": "assists"},
+            {"data": "headshots"},
+            {"data": "rounds_ct"},
+            {"data": "rounds_t"},
+            {"data": "rounds_overall"},
+            {"data": "games_won"},
+            {"data": "games_lost"}
+        ]
+    });
+}
+loadPlayTime();
+
+function truncatePlayerName(playerName: string): string {
+    if (playerName === null) {
+        return "Unknown";
+    } else if (playerName.length > 15) {
+        return playerName.substring(0, 12) + '...';
+    } else {
+        return playerName;
+    }
+}

--- a/resources/views/components/menu/vertical-menu.blade.php
+++ b/resources/views/components/menu/vertical-menu.blade.php
@@ -230,6 +230,13 @@
                                     </div>
                                 </a>
                             </li>
+                            <li class="{{ Request::is('*list/playtime*') ? 'active' : '' }}">
+                                <a href="{{getAppSubDirectoryPath()}}/list/playtime" class="dropdown-toggle">
+                                    <div class="">
+                                        <i class="fas fa-clock fa-fw me-3"></i><span>{{ __('dashboard.playTime') }}</span>
+                                    </div>
+                                </a>
+                            </li>
                         @endif
                         @if(env('VIP') == 'Enabled')
                             <li class="{{ Request::is('*vip*') ? 'active' : '' }}">

--- a/resources/views/k4Ranks/playtime.blade.php
+++ b/resources/views/k4Ranks/playtime.blade.php
@@ -1,0 +1,92 @@
+@php use Illuminate\Support\Facades\Crypt;use Illuminate\Support\Facades\Session; @endphp
+<x-base-layout :scrollspy="false">
+    <x-slot:pageTitle>
+        {{ __('dashboard.playTime') }} - CSS-BANS
+        </x-slot>
+        @vite(['resources/scss/dark/assets/components/datatable.scss'])
+        <!-- BEGIN GLOBAL MANDATORY STYLES -->
+        <x-slot:headerFiles>
+            <link rel="stylesheet" href="{{asset('plugins/notification/snackbar/snackbar.min.css')}}">
+            @vite(['resources/scss/light/plugins/notification/snackbar/custom-snackbar.scss'])
+            </x-slot>
+            @if (session('success'))
+                <x-alert type="success" :message="session('success')"/>
+            @endif
+            @if (session('error'))
+                <x-alert type="danger" :message="session('error')"/>
+            @endif
+            @if ($errors->any())
+                <div class="alert alert-danger">
+                    <ul>
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+            <section class="mb-12">
+                <div class="card">
+                    <div class="card-header text-center py-3">
+                        <h5 class="mb-0 text-center">
+                            <strong>{{ __('dashboard.playTime') }}</strong>
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="rank-servers">
+                            <select class="form-select" id="serverSelect">
+                                @foreach ($servers as $server)
+                                    <option
+                                        {{$server->id == Session::get('Ranks_server') ? 'selected': ''}} value="{{ Crypt::encrypt($server->id) }}">
+                                        {{ $server->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <label for="serverSelect"
+                                   class="serverSelectLabel form-label">{{ __('admins.selectServers') }}</label>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-hover table-borderless" id="playTimeList" style="width:100%">
+                                <thead>
+                                <tr>
+                                    <th>{{ __('dashboard.position') }}</th>
+                                    <th>{{ __('dashboard.player') }}</th>
+                                    <th>{{ __('dashboard.playTime') }}</th>
+                                    <th>{{ __('dashboard.rank') }}</th>
+                                    <th>{{ __('dashboard.kills') }} <i class="fas fa-skull-crossbones"></i></th>
+                                    <th>{{ __('dashboard.deaths') }} <i class="fas fa-skull"></i></th>
+                                    <th>{{ __('admins.assists') }} <i class="fas fa-hands-helping"></i></th>
+                                    <th>{{ __('admins.headhost') }} <i class="fas fa-bullseye"></i></th>
+                                    <th>{{ __('admins.ct') }} <i class="fas fa-trophy"></i></th>
+                                    <th>{{ __('admins.t') }} <i class="fas fa-trophy"></i></th>
+                                    <th>{{ __('admins.overall') }} <i class="fas fa-trophy"></i></th>
+                                    <th>{{ __('admins.gameswon') }} <i class="fas fa-trophy"></i></th>
+                                    <th>{{ __('admins.gameslost') }} <i class="fas fa-times-circle"></i></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <x-slot:footerFiles>
+                @vite(['resources/js/ranks/playtime.ts'])
+                <script>
+                    const playTimeListUrl = '{!! env('VITE_SITE_DIR') !!}/list/playtime';
+                    $(document).ready(function () {
+                        $('#serverSelect').change(function () {
+                            const serverId = $(this).val();
+                            window.location.href = '{{ url()->current() }}' + '?server_id=' + serverId;
+                        });
+                    });
+                    window.translations = {
+                        searchByPlayernameAndSteamid: "{{ __('admins.searchByPlayernameAndSteamid') }}",
+                        lastSeen: "{{ __('dashboard.lastSeen') }}"
+                    };
+                </script>
+                </x-slot>
+</x-base-layout>
+
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,8 @@ Route::middleware(['checkSetup'])->group(function () {
     Route::group(['prefix' => 'list'], function () {
         Route::get('/ranks', [RanksController::class, 'index']);
         Route::post('/ranks', [RanksController::class, 'getPlayersList']);
+        Route::get('/playtime', [RanksController::class, 'playtime']);
+        Route::post('/playtime', [RanksController::class, 'getPlaytimeList']);
     });
     Route::get('/ranks/profile/{steam_id}/{server_id}', [RanksController::class, 'viewProfile'])->name('ranks.profile');
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -205,6 +205,7 @@ export default defineConfig({
                 'resources/js/groups/groups.ts',
                 'resources/js/groups/edit.ts',
                 'resources/js/ranks/ranks.ts',
+                'resources/js/ranks/playtime.ts',
                 'resources/js/admin/delete.ts',
                 'resources/js/nav.js',
                 'resources/js/vip/list.ts',


### PR DESCRIPTION
## Summary
- add a dedicated ranks listing ordered by play time
- support retrieving top playtime data via controller
- create DataTable script for playtime ranks
- wire new view and menu entry
- add translation for "Play Time"

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6c9fe88832eb08d63524e30ff89