### PR TITLE
Fixed a bug where on some systems 'users'.steam_id wasn't cast properly

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,7 +28,7 @@ class User extends Authenticatable
      * @var array<string, string>
      */
     protected $casts = [
-        'steam_id' => 'int'
+        'steam_id' => 'string'
     ];
 
     public function __construct(array $attributes = [])


### PR DESCRIPTION
Fixed a bug where on some systems 'users'.steam_id wasn't cast properly to string, causing on some system to not match correctly between `users` and `sa_admins`.