### PR TITLE
fix(auth): gate VIP/Appeal/Report admin actions with admin middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -124,8 +124,10 @@ Route::get('/rcon/{server_id?}', [RconController::class, 'index'])->middleware('
 Route::post('/rcon/{server_id}', [RconController::class, 'execute'])->middleware('superadmin')->name('rcon.execute');
 
 if(env('VIP') == 'Enabled') {
-    Route::resource('vip', VIPController::class);
-    Route::post('vip/list', 'VIPController@getVIPsList')->name('vip.list');
+    Route::middleware(['admin'])->group(function () {
+        Route::resource('vip', VIPController::class);
+        Route::post('vip/list', 'VIPController@getVIPsList')->name('vip.list');
+    });
 }
 
 use App\Http\Controllers\WeaponSkinController;
@@ -171,20 +173,28 @@ Route::middleware(['superadmin'])->group(function () {
 });
 
 if(env('APPEALS') == 'Enabled') {
-    Route::get('/appeals', [AppealController::class, 'list'])->name('appeals.list');
+    // Public — banned players submit appeals
     Route::get('/appeals/create', [AppealController::class, 'create'])->name('appeals.create');
     Route::post('appeals', [AppealController::class, 'store'])->name('appeals.store');
-    Route::get('/appeals/{id}', [AppealController::class, 'view'])->name('appeals.show');
-    Route::put('/appeals/{id}/status', [AppealController::class, 'updateStatus'])->name('appeals.updateStatus');
+    // Admin-only — viewing all appeals and changing their status
+    Route::middleware(['admin'])->group(function () {
+        Route::get('/appeals', [AppealController::class, 'list'])->name('appeals.list');
+        Route::get('/appeals/{id}', [AppealController::class, 'view'])->name('appeals.show');
+        Route::put('/appeals/{id}/status', [AppealController::class, 'updateStatus'])->name('appeals.updateStatus');
+    });
 }
 
 if(env('REPORTS') == 'Enabled') {
     Route::prefix('reports')->group(function () {
+        // Public — any player can submit a report
         Route::get('create', [ReportController::class, 'create'])->name('reports.create');
         Route::post('store', [ReportController::class, 'store'])->name('reports.store');
-        Route::get('list', [ReportController::class, 'list'])->name('reports.list');
-        Route::get('show/{id}', [ReportController::class, 'show'])->name('reports.show');
-        Route::delete('destroy/{id}', [ReportController::class, 'destroy'])->name('reports.destroy');
+        // Admin-only — viewing/deleting reports
+        Route::middleware(['admin'])->group(function () {
+            Route::get('list', [ReportController::class, 'list'])->name('reports.list');
+            Route::get('show/{id}', [ReportController::class, 'show'])->name('reports.show');
+            Route::delete('destroy/{id}', [ReportController::class, 'destroy'])->name('reports.destroy');
+        });
     });
 }
 


### PR DESCRIPTION
## Summary

Three route blocks in `routes/web.php` mutate state but currently have **no admin permission check** — any authenticated user can hit them. This PR wraps the admin-only routes in `Route::middleware(['admin'])->group(...)` while keeping the public submission endpoints (appeal create, report create) open.

## Vulnerabilities fixed

| Module | Route | Was | Now |
|---|---|---|---|
| **VIP** | entire `Route::resource('vip', ...)` + `POST /vip/list` | open to any authed user | `admin` middleware |
| **Appeals** | `GET /appeals` (list)<br>`GET /appeals/{id}` (view)<br>`PUT /appeals/{id}/status` | open to any authed user | `admin` middleware |
| **Reports** | `GET /reports/list`<br>`GET /reports/show/{id}`<br>`DELETE /reports/destroy/{id}` | open to any authed user | `admin` middleware |

Public submission endpoints are unchanged so banned players can still file appeals and any player can still report:

- `GET /appeals/create`, `POST /appeals` — public
- `GET /reports/create`, `POST /reports/store` — public

## Repro (before this PR)

1. Log in via Steam as a non-admin user.
2. Send `DELETE /reports/destroy/1` — the report is deleted.
3. Send `PUT /appeals/1/status` with status=APPROVED — appeal is approved.
4. Send `DELETE /vip/1` — VIP record is deleted.

With this PR all four return `403 Unauthorized` unless the user passes the `admin` middleware (`@css/root`, `@web/admin.create`, or `@web/admin.edit`).

## Why `admin` and not new VIP/appeal-specific middleware?

`PermissionsHelper` already has granular `hasVipCreatePermission` / `hasVipEditPermission` / `hasVipDeletePermission`, but no middleware is wired to them today. Wiring three new middleware classes is a larger change; this PR keeps the patch minimal by reusing the existing `admin` alias (same pattern as `/admin/create`, `/group/create`, etc.). A follow-up could split each verb to its own granular middleware.

## Test plan

- [ ] Log in as a user without admin flags; confirm `/appeals/{id}/status`, `/reports/destroy/{id}`, `/vip/{id}` all return 403.
- [ ] Log in as an `@css/root` superadmin; confirm all routes still work.
- [ ] Confirm public `/appeals/create` and `/reports/create` still load without auth.
